### PR TITLE
Remove process to keep file size small

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,6 @@
 module.exports = browserSupportsLogStyles
 
 function browserSupportsLogStyles () {
-  // don’t run in node
-  if (!process.browser) {
-    return false
-  }
-
   // don’t run in non-browser environments
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return false

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,8 +3,6 @@ var browserSupportsLogStyles = require('../index')
 
 // simulate browser environment
 function resetBrowserEnvironment (options) {
-  process.browser = true
-
   global.window = ('window' in options) ? options.window : {
     console: {}
   }
@@ -87,14 +85,6 @@ test('browserSupportsLogStyles with firebug', function (t) {
   })
 
   t.is(browserSupportsLogStyles(), true, 'is true if console.exception & .table are functions')
-
-  t.end()
-})
-
-test('browserSupportsLogStyles in Node', function (t) {
-  delete process.browser
-
-  t.is(browserSupportsLogStyles(), false, 'is false')
 
   t.end()
 })


### PR DESCRIPTION
I was excited how small if you library.

But in `webpack` it increase size of build to 1KB. Reason of it is `process` — `webpack` loads 1KB polyfill for it.

The problem is that whole my library is 1KB. So `browser-supports-log-styles` increase my library size in 2 times.

I think we could not test node, because we already test `window` and `document`.

closes https://github.com/gr2m/browser-supports-log-styles/issues/24