### PR TITLE
[edge browsers]: filter out by `userAgent`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ function browserSupportsLogStyles () {
     return false
   }
 
+  // edge browser? https://msdn.microsoft.com/en-us/library/hh869301%28v=vs.85%29.aspx
+  var isEdge = navigator.userAgent.toLowerCase().indexOf('edge') > -1
   // http://stackoverflow.com/a/16459606/376773
   var isWebkit = 'WebkitAppearance' in document.documentElement.style
   // http://stackoverflow.com/a/398120/376773
@@ -13,5 +15,5 @@ function browserSupportsLogStyles () {
   // firefox >= v31? https://developer.mozilla.org/en-US/docs/Tools/Web_Console#Styling_messages
   var isFirefoxWithLogStyleSupport = navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/) && parseInt(RegExp.$1, 10) >= 31
 
-  return isWebkit || isFirebug || isFirefoxWithLogStyleSupport || false
+  return (isWebkit && !isEdge) || isFirebug || isFirefoxWithLogStyleSupport || false
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -40,6 +40,25 @@ test('browserSupportsLogStyles in WebKit browser', function (t) {
   t.end()
 })
 
+test('browserSupportsLogStyles in Edge browser', function (t) {
+  resetBrowserEnvironment({
+    document: {
+      documentElement: {
+        style: {
+          WebkitAppearance: 'foo'
+        }
+      }
+    },
+    navigator: {
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136'
+    }
+  })
+
+  t.is(browserSupportsLogStyles(), false, 'is false')
+
+  t.end()
+})
+
 test('browserSupportsLogStyles in Firefox 30', function (t) {
   resetBrowserEnvironment({
     navigator: {


### PR DESCRIPTION
The `'WebkitAppearance' in document.documentElement.style` check returns `true` for all `Edge` browsers, at the same time `console styling` is “work in progress” for the `Edge` and isn’t supported yet. Thus this results in broken `console` message.

This PR filters out all `Edge` browsers. This should be revisited when the feature will get better support (recheck at October 2017).